### PR TITLE
Enhancements, updates, and bug fixes.

### DIFF
--- a/AAXtoMP3
+++ b/AAXtoMP3
@@ -1,64 +1,79 @@
 #!/usr/bin/env bash
 
+# AAXtoMP3 - Convert Audible AAX/AAXC files to MP3/M4A/M4B
+# Original by krad (https://github.com/krad/AAXtoMP3)
+# Modified by kcrvM4, 2025-09-26:
+# - Updated mp4art/mp4chaps warning messages to reflect deprecated mp4v2-utils package and link to enzo1982/mp4v2.
+# - Added jq dependency check for --use-audible-cli-data.
+# - Added sanitized_title and sanitized_artist to replace invalid characters (/, \, *, <, >, |, ?, ") with _, colons with ' -', semicolons with ',', and delete periods for directory/file/chapter naming.
+# - Added annotation file copying (-annotations.json) and .csv generation (with Type, Start Time, End Time, Note headers) to output directory using sanitized_title for --use-audible-cli-data.
+# - Added cover_embedded/chapters_embedded variables to track successful embedding and clean up cover.jpg/*.chapters.txt only when embedded.
+# - Added chapter ffprobe fallback in case of invalid chapter file.
+# - Enhanced `validate_extra_files` to select highest-resolution cover art (e.g., `BookTitle_(1215).jpg`).
+# - Updated `save_metadata` to flatten nested chapters (e.g., `Part I` > `Chapter One`) for correct `--chaptered` splitting.
+# - Added `--no-cleanup` flag to keep temporary files (`.jpg`, `.chapters.txt`).
+# Dependencies: ffmpeg (6.1.1), jq (1.6+), bc, mp4v2 (built from https://github.com/enzo1982/mp4v2).
+# Tested on Linux Mint 22.2 Zara with 100+ Audible .aaxc files.
 
 # ========================================================================
 # Command Line Options
 
 # Usage Synopsis.
 usage=$'\nUsage: AAXtoMP3 [--flac] [--aac] [--opus ] [--single] [--level <COMPRESSIONLEVEL>]
-[--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-clobber]
+[--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [--authcode <AUTHCODE>] [--no-cleanup] [--no-clobber]
 [--target_dir <PATH>] [--complete_dir <PATH>] [--validate] [--loglevel <LOGLEVEL>]
 [--keep-author <N>] [--author <AUTHOR>] [--{dir,file,chapter}-naming-scheme <STRING>]  
 [--use-audible-cli-data] [--audible-cli-library-file <LIBRARY_PATH>] [--continue <CHAPTERNUMBER>] {FILES}\n'
 codec=libmp3lame            # Default encoder.
 extension=mp3               # Default encoder extension.
 level=-1                    # Compression level. Can be given for mp3, flac and opus. -1 = default/not specified.
-mode=chaptered              # Multi file output
+mode=chaptered              # Multi file output.
 auth_code=                  # Required to be set via file or option.
 targetdir=                  # Optional output location.  Note default is basedir of AAX file.
-dirNameScheme=              # Custom directory naming scheme, default is $genre/$artist/$title
+dirNameScheme=              # Custom directory naming scheme, default is $genre/$artist/$title.
 customDNS=0
-fileNameScheme=             # Custom file naming scheme, default is $title
+fileNameScheme=             # Custom file naming scheme, default is $title.
 customFNS=0
-chapterNameScheme=          # Custom chapter naming scheme, default is '$title-$(printf %0${#chaptercount}d $chapternum) $chapter' (BookTitle-01 Chapter 1)
+chapterNameScheme=          # Custom chapter naming scheme, default is '$title-$(printf %0${#chaptercount}d $chapternum) $chapter' (BookTitle-01 Chapter 1).
 customCNS=0
 completedir=                # Optional location to move aax files once the decoding is complete.
-container=mp3               # Just in case we need to change the container.  Used for M4A to M4B
-VALIDATE=0                  # Validate the input aax file(s) only.  No Transcoding of files will occur
-loglevel=1                  # Loglevel: 0: Show progress only; 1: default; 2: a little more information, timestamps; 3: debug
-noclobber=0                 # Default off, clobber only if flag is enabled
+container=mp3               # Just in case we need to change the container.  Used for M4A to M4B.
+VALIDATE=0                  # Validate the input aax file(s) only.  No Transcoding of files will occur.
+loglevel=1                  # Loglevel: 0: Show progress only; 1: default; 2: a little more information, timestamps; 3: debug.
+nocleanup=0                 # Default off, skip file cleanup only if flag is enabled.
+noclobber=0                 # Default off, clobber only if flag is enabled.
 continue=0                  # Default off, If set Transcoding is skipped and chapter splitting starts at chapter continueAt.
 continueAt=1                # Optional chapter to continue splitting the chapters.
-keepArtist=-1               # Default off, if set change author metadata to use the passed argument as field
-authorOverride=             # Override the author, ignoring the metadata           
-audibleCli=0                # Default off, Use additional data gathered from mkb79/audible-cli
-aaxc_key=                   # Initialize variables, in case we need them in debug_vars
-aaxc_iv=                    # Initialize variables, in case we need them in debug_vars
-ffmpegPath=                 # Set a custom path, useful for using the updated version that supports aaxc
-ffmpegName=ffmpeg           # Set a custom ffmpeg binary name, useful tailoring to local setup
-ffprobeName=ffprobe         # Set a custom ffprobe binary name, useful tailoring to local setup
-library_file=               # Libraryfile generated by mkb79/audible-cli
+keepArtist=-1               # Default off, if set change author metadata to use the passed argument as field.
+authorOverride=             # Override the author, ignoring the metadata.
+audibleCli=0                # Default off, Use additional data fetched from mkb79/audible-cli.
+aaxc_key=                   # Initialize variables, in case we need them in debug_vars.
+aaxc_iv=                    # Initialize variables, in case we need them in debug_vars.
+ffmpegPath=                 # Set a custom path, useful for using the updated version that supports aaxc.
+ffmpegName=ffmpeg           # Set a custom ffmpeg binary name, useful tailoring to local setup.
+ffprobeName=ffprobe         # Set a custom ffprobe binary name, useful tailoring to local setup.
+library_file=               # Libraryfile generated by mkb79/audible-cli.
 
 # -----
 # Code tip Do not have any script above this point that calls a function or a binary.  If you do
 # the $1 will no longer be a ARGV element.  So you should only do basic variable setting above here.
 #
-# Process the command line options.  This allows for un-ordered options. Sorta like a getops style
+# Process the command line options.  This allows for un-ordered options. Sorta like a getops style.
 while true; do
   case "$1" in
-                      # Flac encoding
+                      # Flac encoding.
     -f | --flac       ) codec=flac; extension=flac; mode=single; container=flac;        shift ;;
-                      # Ogg Format
+                      # Ogg Format.
     -o | --opus       ) codec=libopus; extension=opus; container=ogg;                   shift ;;
-                      # If appropriate use only a single file output.
+                      # If appropriate use only a single file output. Default format is .mp3.
     -s | --single     ) mode=single;                                                    shift ;;
-                      # If appropriate use only a single file output.
+                      # Split output into separate files per chapter.
     -c | --chaptered  ) mode=chaptered;                                                 shift ;;
                       # This is the same as --single option.
     -e:mp3            ) codec=libmp3lame; extension=mp3; mode=single; container=mp3;    shift ;;
-                      # Identical to --acc option.
-    -e:m4a | -a | --aac ) codec=copy; extension=m4a; mode=single; container=mp4;          shift ;;
-                      # Similar to --aac but specific to audio books
+                      # Apple m4a music format.
+    -e:m4a | -a | --aac ) codec=copy; extension=m4a; mode=single; container=mp4;        shift ;;
+                      # Similar to --aac but specific to audio books.
     -e:m4b            ) codec=copy; extension=m4b; mode=single; container=mp4;          shift ;;
                       # Change the working dir from AAX directory to what you choose.
     -t | --target_dir ) targetdir="$2";                                                 shift 2 ;;
@@ -70,34 +85,36 @@ while true; do
     --chapter-naming-scheme ) chapterNameScheme="$2"; customCNS=1;                      shift 2 ;;
                       # Move the AAX file to a new directory when decoding is complete.
     -C | --complete_dir ) completedir="$2";                                             shift 2 ;;
-                      # Authorization code associate with the AAX file(s)
+                      # Authorization code associated with the AAX file(s).
     -A | --authcode   ) auth_code="$2";                                                 shift 2 ;;
-                      # Don't overwrite the target directory if it already exists
+                      # Don't delete cover.jpg and/or chapter.txt files after successful embedding.
+    -N | --no-cleanup ) nocleanup=1;                                                    shift ;;
+                      # Don't overwrite the target directory if it already exists.
     -n | --no-clobber ) noclobber=1;                                                    shift ;;
                       # Extremely verbose output.
     -d | --debug      ) loglevel=3;                                                     shift ;;
                       # Set loglevel.
     -l | --loglevel   ) loglevel="$2";                                                  shift 2 ;;
-                      # Validate ONLY the aax file(s) No transcoding occurs
+                      # Validate ONLY the aax file(s) No transcoding occurs.
     -V | --validate   ) VALIDATE=1;                                                     shift ;;
-                      # continue splitting chapters at chapter continueAt
+                      # Continue splitting chapters at chapter continueAt.
     --continue        ) continueAt="$2"; continue=1;                                    shift 2 ;;
-                      # Use additional data got with mkb79/audible-cli
+                      # Use additional data fetched with mkb79/audible-cli.
     --use-audible-cli-data ) audibleCli=1;                                              shift ;;
-                      # Path of the library-file, generated by mkb79/audible-cli (audible library export -o ./library.tsv)
+                      # Path of the library-file, generated by mkb79/audible-cli (audible library export -o ./library.tsv).
     -L | --audible-cli-library-file ) library_file="$2";                                shift 2 ;;
-                      # Compression level
+                      # Compression level.
     --level           ) level="$2";                                                     shift 2 ;;
-                      # Keep author number n
+                      # Keep author number n.
     --keep-author     ) keepArtist="$2";                                                shift 2 ;;
                       # Author override
     --author          ) authorOverride="$2";                                            shift 2 ;;
-                      # Ffmpeg path override
+                      # Ffmpeg path override.
     --ffmpeg-path     ) ffmpegPath="$2";                                                shift 2 ;;
-                      # Ffmpeg name override
+                      # Ffmpeg name override.
     --ffmpeg-name     ) ffmpegName="$2";                                                shift 2 ;;
-                      # Ffprobe name override
-    --ffprobe-name    ) ffprobeName="$2";                                                shift 2 ;;
+                      # Ffprobe name override.
+    --ffprobe-name    ) ffprobeName="$2";                                               shift 2 ;;
                       # Command synopsis.
     -h | --help       ) printf "$usage" $0 ;                                            exit ;;
                       # Standard flag signifying the end of command line processing.
@@ -267,7 +284,7 @@ if [[ "x$(type -P "$FFMPEG")" == "x" ]]; then
   echo "Without it, this script will break."
   echo "INSTALL:"
   echo "MacOS:           brew install ffmpeg"
-  echo "Ubuntu:          sudo apt-get update; sudo apt-get install ffmpeg libav-tools x264 x265 bc"
+  echo "Ubuntu:          sudo apt-get update; sudo apt-get install ffmpeg x264 x265 bc"
   echo "Ubuntu (20.04):  sudo apt-get update; sudo apt-get install ffmpeg x264 x265 bc"
   echo "RHEL:            yum install ffmpeg"
   exit 1
@@ -280,7 +297,7 @@ if [[ "x$(type -P "$FFPROBE")" == "x" ]]; then
   echo "Without it, this script will break."
   echo "INSTALL:"
   echo "MacOS:   brew install ffmpeg"
-  echo "Ubuntu:  sudo apt-get update; sudo apt-get install ffmpeg libav-tools x264 x265 bc"
+  echo "Ubuntu:  sudo apt-get update; sudo apt-get install ffmpeg x264 x265 bc"
   echo "RHEL:    yum install ffmpeg"
   exit 1
 fi
@@ -289,31 +306,52 @@ fi
 # -----
 # Detect if we need mp4art for cover additions to m4a & m4b files.
 if [[ "x${container}" == "xmp4" && "x$(type -P mp4art)" == "x" ]]; then
-  echo "WARN mp4art was not found on your env PATH variable"
+  echo "WARNING mp4art was not found on your env PATH variable"
   echo "Without it, this script will not be able to add cover art to"
-  echo "m4b files. Note if there are no other errors the AAXtoMP3 will"
+  echo "m4b files. Note if there are no other errors, the AAXtoMP3 will"
   echo "continue. However no cover art will be added to the output."
   echo "INSTALL:"
   echo "MacOS:   brew install mp4v2"
-  echo "Ubuntu:  sudo apt-get install mp4v2-utils"
+  echo "Debian/Ubuntu: build from https://github.com/enzo1982/mp4v2 (the"
+  echo "mp4v2-utils package has been deprecated and removed, as the upstream"
+  echo "project is no longer maintained. The package was removed in Debian"
+  echo "Buster, and Ubuntu Focal [ 20.04 ].)"
 fi
 
 # -----
 # Detect if we need mp4chaps for adding chapters to m4a & m4b files.
 if [[ "x${container}" == "xmp4" && "x$(type -P mp4chaps)" == "x" ]]; then
-  echo "WARN mp4chaps was not found on your env PATH variable"
+  echo "WARNING mp4chaps was not found on your env PATH variable"
   echo "Without it, this script will not be able to add chapters to"
-  echo "m4a/b files. Note if there are no other errors the AAXtoMP3 will"
+  echo "m4a/b files. Note if there are no other errors, the AAXtoMP3 will"
   echo "continue. However no chapter data will be added to the output."
   echo "INSTALL:"
   echo "MacOS:   brew install mp4v2"
-  echo "Ubuntu:  sudo apt-get install mp4v2-utils"
+  echo "Debian/Ubuntu: build from https://github.com/enzo1982/mp4v2 (the"
+  echo "mp4v2-utils package has been deprecated and removed, as the upstream"
+  echo "project is no longer maintained. The package was removed in Debian"
+  echo "Buster, and Ubuntu Focal [ 20.04 ].)"
+fi
+
+# -----
+# Detect if jq is needed for chapter parsing and annotations CSV with audible-cli
+if [[ "${audibleCli}" == "1" && -z "$(type -P jq)" ]]; then
+  echo "WARNING jq was not found on your PATH."
+  echo "Without jq, this script cannot parse chapters from *-chapters.json"
+  echo "or create *-annotations.csv files when using --use-audible-cli-data."
+  echo "It will fall back to ffprobe for chapter extraction, which may result"
+  echo "in less accurate chapter data or no chapters in the output. The"
+  echo "*-annotations.json file will still be copied to the output folder if"
+  echo "present."
+  echo "INSTALL:"
+  echo "MacOS:   brew install jq"
+  echo "  Debian/Ubuntu: sudo apt install jq"
 fi
 
 # -----
 # Detect if we need mediainfo for adding description and narrator
 if [[ "x$(type -P mediainfo)" == "x" ]]; then
-  echo "WARN mediainfo was not found on your env PATH variable"
+  echo "WARNING mediainfo was not found on your env PATH variable"
   echo "Without it, this script will not be able to add the narrator"
   echo "and description tags. Note if there are no other errors the AAXtoMP3"
   echo "will continue. However no such tags will be added to the output."
@@ -451,7 +489,7 @@ validate_aax() {
 }
 
 validate_extra_files() {
-  local extra_media_file extra_find_command
+  local extra_media_file extra_cover_select
   extra_media_file="$1"
   # Bash trick to delete, non greedy, from the end up until the first '-'
   extra_title="${extra_media_file%-*}"
@@ -465,15 +503,22 @@ validate_extra_files() {
   # Chapter
   extra_chapter_file="${extra_title}-chapters.json"
 
-  # Cover
+  # Cover: select the highest resolution cover art file if multiple covers exist
   extra_dirname="$(dirname "${extra_media_file}")"
-  extra_find_command='$FIND "${extra_dirname}" -maxdepth 1 -regex ".*/${extra_title##*/}_([0-9]+)\.jpg"'
-  # We want the output of the find command, we will turn errexit on later
-  set +e errexit
-  extra_cover_file="$(eval ${extra_find_command})"
-  extra_eval_comm="$(eval echo ${extra_find_command})"
-  set -e errexit
+  max_res=0
+  selected_file=""
+  for file in "${extra_dirname}/${extra_title##*/}_"*\([0-9]*\).jpg; do
+    if [ -f "$file" ]; then
+      res=$(basename "$file" | grep -o '([0-9]\+)' | grep -o '[0-9]\+')
+      if [ "$res" -gt "$max_res" ]; then
+        max_res="$res"
+        selected_file="$file"
+      fi
+    fi
+  done
+  extra_cover_file="$selected_file"
 
+  # Voucher
   if [[ "${aaxc}" == "1" ]]; then
     # bash trick to get file w\o extention (delete from end to the first '.')
     extra_voucher="${extra_media_file%.*}.voucher"
@@ -485,7 +530,7 @@ validate_extra_files() {
     aaxc_iv=$(jq -r '.content_license.license_response.iv' "${extra_voucher}")
   fi
 
-  debug_vars "Audible-cli variables" extra_media_file extra_title extra_chapter_file extra_cover_file extra_find_command extra_eval_comm extra_dirname extra_voucher aaxc_key aaxc_iv
+  debug_vars "Audible-cli variables" extra_media_file extra_title extra_chapter_file extra_cover_file extra_dirname extra_voucher aaxc_key aaxc_iv
 
   # Test for chapter file existence
   if [[ ! -r "${extra_chapter_file}" ]] ; then
@@ -537,8 +582,13 @@ save_metadata() {
     # put a ',' after the start value, we calculate the end of each chapter
     # as start+length, and we convert (divide) the time stamps from ms to s.
     # Then we delete all ':' and '/' since they make a filename invalid.
-    jq -r '.content_metadata.chapter_info.chapters[] | "Chapter # start: \(.start_offset_ms/1000), end: \((.start_offset_ms+.length_ms)/1000) \n#\n# Title: \(.title)"' "${extra_chapter_file}" \
-      | $SED 's@[:/]@@g' >> "$metadata_file"
+    jq -r \
+      '.content_metadata.chapter_info.chapters |
+       reduce .[] as $c ([]; if $c.chapters? then .+[$c | del(.chapters)]+[$c.chapters] else .+[$c] end) | flatten |
+       to_entries |
+       .[] |
+       "Chapter # start: \(.value.start_offset_ms/1000), end: \((.value.start_offset_ms+.value.length_ms)/1000) \n#\n# Title: \(.value.title)"' "${extra_chapter_file}" \
+       | $SED 's@[:/]@@g' >> "$metadata_file"
     # In case we want to use a single file m4b we need to extract the
     # chapter titles from the .json generated by audible–cli and store
     # them correctly formatted for mp4chaps in a chapter.txt
@@ -682,6 +732,10 @@ do
   series="$(get_metadata_value series)"
   series_sequence="$(get_metadata_value series_sequence)"
 
+  # Sanitize title and artist for directory/file naming to handle invalid characters (:, ;, ., /, \, *, <, >, |, ?, ")
+  sanitized_title=$(echo "${title}" | sed 's/[\\/*<>|?"]/_/g; s/[:]/ -/g; s/[;]/,/g; s/[.]//g')
+  sanitized_artist=$(echo "${artist}" | sed 's/[\\/*<>|?"]/_/g; s/[:]/ -/g; s/[;]/,/g; s/[.]//g')
+
   # Get more tags with mediainfo
   if [[ $(type -P mediainfo) ]]; then
     narrator="$(get_metadata_value nrt)"
@@ -698,7 +752,7 @@ do
     currentDirNameScheme="$(eval echo "${dirNameScheme}")"
   else
     # The Default
-    currentDirNameScheme="${genre}/${artist}/${title}"
+    currentDirNameScheme="${genre}/${sanitized_artist}/${sanitized_title}"
   fi
 
   # If we defined a target directory, use it. Otherwise use the location of the AAX file
@@ -713,13 +767,13 @@ do
     currentFileNameScheme="$(eval echo "${fileNameScheme}")"
   else
     # The Default
-    currentFileNameScheme="${title}"
+    currentFileNameScheme="${sanitized_title}"
   fi
   output_file="${output_directory}/${currentFileNameScheme}.${extension}"
 
   if [[ "${noclobber}" = "1" ]] && [[ -d "${output_directory}" ]]; then
     log "Noclobber enabled but directory '${output_directory}' exists. Skipping to avoid overwriting"
-    rm -f "${metadata_file}" "${tmp_chapter_file}"
+    rm -f "${metadata_file}"
     continue
   fi
   mkdir -p "${output_directory}"
@@ -818,6 +872,10 @@ do
     extra_crop_cover='-vf crop=trunc(iw/2)*2:trunc(ih/2)*2'
   fi
 
+  # Track successful embedding for cleanup
+  cover_embedded=0
+  chapters_embedded=0
+
   # -----
   # If mode=chaptered, split the big converted file by chapter and remove it afterwards.
   # Not all audio encodings make sense with multiple chapter outputs (see options section)
@@ -874,7 +932,7 @@ do
           chapter_title="$(eval echo "${chapterNameScheme}")"
         else
           # The Default
-          chapter_title="${title}-$(printf %0${#chaptercount}d $chapternum) ${chapter}"
+          chapter_title="${sanitized_title}-$(printf %0${#chaptercount}d $chapternum) ${chapter}"
         fi
         chapter_file="${output_directory}/${chapter_title}.${extension}"
 
@@ -944,6 +1002,7 @@ do
 
     # Clean up of working directory stuff.
     rm "${output_file}"
+    cover_embedded=1
     if [ "$((${loglevel} > 1))" == "1" ]; then
       log "Done creating chapters for ${output_directory}."
     else
@@ -951,46 +1010,78 @@ do
       echo ""
     fi
   else
-    # Perform file tasks on output file.
-    # ----
-    # ffmpeg seems to copy only chapter position, not chapter names.
-    # use already created chapter.txt from save_metadata() in case
-    # audible-cli data is used else use ffprobe to extract from m4b
-    if [[ ${container} == "mp4" && $(type -P mp4chaps) ]]; then
-      if [ "${audibleCli}" == "1" ]; then
-        mv "${tmp_chapter_file}" "${output_directory}/${currentFileNameScheme}.chapters.txt"
-      else
-        "$FFPROBE" -i "${aax_file}" -print_format csv -show_chapters 2>/dev/null | awk -F "," '{printf "CHAPTER%d=%02d:%02d:%02.3f\nCHAPTER%dNAME=%s\n", NR, $5/60/60, $5/60%60, $5%60, NR, $8}' > "${output_directory}/${currentFileNameScheme}.chapters.txt"
-      fi
-      $SED -i 's/\,000/\.000/' "${output_directory}/${currentFileNameScheme}.chapters.txt"
-      mp4chaps -i "${output_file}"
-    fi
-  fi
+  # Perform file tasks on output file.
+  # ----
 
-  if [ -f "${cover_file}" ]; then
-    log "Adding cover art"
-    # FFMPEG does not support MPEG-4 containers fully #
-    if [ "${container}" == "mp4" ] ; then
-      mp4art --add "${cover_file}" "${output_file}"
-    # FFMPEG for everything else #
-    else
-      # Create temporary output file name - ensure extention matches previous appropriate output file to keep ffmpeg happy
-      cover_output_file="${output_file%.*}.cover.${output_file##*.}"
-      # Copy audio stream from current output, and video stream from cover file, setting appropriate metadata
-      </dev/null "$FFMPEG" -loglevel quiet \
-        -nostats \
-        -i "${output_file}" \
-        -i "${cover_file}" \
-        -map 0:a:0 \
-        -map 1:v:0 \
-        -acodec copy \
-        -vcodec copy \
-        -id3v2_version 3 \
-        -metadata:s:v title="Album cover" \
-        -metadata:s:v comment="Cover (front)" \
-        "${cover_output_file}"
-        # Replace original output file with version including cover
-        mv "${cover_output_file}" "${output_file}"
+    # Embed chapters
+    # ffmpeg seems to copy only chapter position, not chapter names.
+    # use already created chapters.txt from save_metadata() in case
+    # audible-cli data is used else use ffprobe to extract from m4b
+    # Use chapter.txt from save_metadata for audible-cli, else ffprobe
+    if [[ "${container}" == "mp4" && -n "$(type -P mp4chaps)" ]]; then
+      if [[ "${audibleCli}" == "1" && -f "${tmp_chapter_file}" ]]; then
+        # For audible-cli JSON chapters, use already created (jq-generated) chapters.txt file
+        mv "${tmp_chapter_file}" "${output_directory}/${currentFileNameScheme}.chapters.txt"
+        if mp4chaps -z -i "${output_file}"; then
+          chapters_embedded=1
+        else
+          log "WARNING: Failed to embed chapters from JSON for ${output_file}, falling back to ffprobe"
+          rm "${tmp_chapter_file}"  
+          "$FFPROBE" -i "${aax_file}" -print_format csv -show_chapters 2>/dev/null | awk -F "," '{printf "CHAPTER%d=%02d:%02d:%02.3f\nCHAPTER%dNAME=%s\n", NR, $5/60/60, $5/60%60, $5%60, NR, $8}' > "${output_directory}/${currentFileNameScheme}.chapters.txt"
+          $SED -i 's/,000/\.000/' "${output_directory}/${currentFileNameScheme}.chapters.txt"
+          if mp4chaps -z -i "${output_file}"; then
+            chapters_embedded=1
+          else
+            log "WARNING: Failed to embed chapters from ffprobe for ${output_file}"
+          fi
+        fi
+      else
+        # For ffprobe
+        rm "${tmp_chapter_file}"  
+        "$FFPROBE" -i "${aax_file}" -print_format csv -show_chapters 2>/dev/null | awk -F "," '{printf "CHAPTER%d=%02d:%02d:%02.3f\nCHAPTER%dNAME=%s\n", NR, $5/60/60, $5/60%60, $5%60, NR, $8}' > "${output_directory}/${currentFileNameScheme}.chapters.txt"
+        $SED -i 's/,000/\.000/' "${output_directory}/${currentFileNameScheme}.chapters.txt"
+        if mp4chaps -z -i "${output_file}"; then
+          chapters_embedded=1
+        else
+          log "WARNING: Failed to embed chapters from ffprobe for ${output_file}"
+        fi
+      fi
+    fi
+  
+    # Embed cover art
+    if [ -f "${cover_file}" ]; then
+      log "Adding cover art"
+      # FFMPEG does not support MPEG-4 containers fully #
+      if [ "${container}" == "mp4" ] ; then
+	      if mp4art -z --add "${cover_file}" "${output_file}"; then
+	        cover_embedded=1
+	      else
+    	    log "WARNING Failed to embed cover art for ${output_file}"
+	      fi
+      # FFMPEG for everything else #
+      else
+        # Create temporary output file name - ensure extention matches previous appropriate output file to keep ffmpeg happy
+        cover_output_file="${output_file%.*}.cover.${output_file##*.}"
+        # Copy audio stream from current output, and video stream from cover file, setting appropriate metadata
+        </dev/null "$FFMPEG" -loglevel quiet \
+          -nostats \
+          -i "${output_file}" \
+          -i "${cover_file}" \
+          -map 0:a:0 \
+          -map 1:v:0 \
+          -acodec copy \
+          -vcodec copy \
+          -id3v2_version 3 \
+          -metadata:s:v title="Album cover" \
+          -metadata:s:v comment="Cover (front)" \
+          "${cover_output_file}"
+          # Replace original output file with version including cover
+        if mv "${cover_output_file}" "${output_file}"; then
+          cover_embedded=1
+        else
+          log "WARNING Failed to embed cover art for ${output_file}"
+        fi        
+      fi
     fi
   fi
 
@@ -1001,6 +1092,31 @@ do
   fi
   # Lastly get rid of any extra stuff.
   rm "${metadata_file}"
+
+  # Clean up cover art and chapter files if embedded
+  if [ "${nocleanup}" == "0" ]; then
+    if [ "${cover_embedded}" == "1" ] && [ -f "${output_directory}/${currentFileNameScheme}.jpg" ]; then
+      debug "Removing cover art file ${output_directory}/${currentFileNameScheme}.jpg"
+      rm "${output_directory}/${currentFileNameScheme}.jpg" || log "WARNING Failed to remove cover file: ${output_directory}/${currentFileNameScheme}.jpg"
+    fi
+    if [ "${chapters_embedded}" == "1" ] && [ -f "${output_directory}/${currentFileNameScheme}.chapters.txt" ]; then
+      debug "Removing chapter file ${output_directory}/${currentFileNameScheme}.chapters.txt"
+      rm "${output_directory}/${currentFileNameScheme}.chapters.txt" || log "WARNING Failed to remove chapter file: ${output_directory}/${currentFileNameScheme}.chapters.txt"
+    fi
+  else
+    debug "Skipping cleanup due to --no-cleanup flag"
+  fi
+
+  # Copy annotation file and generate CSV if available
+  if [ "${audibleCli}" == "1" ]; then
+    extra_annotation_file="${extra_dirname}/${extra_title##*/}-annotations.json"
+    if [ -f "${extra_annotation_file}" ]; then
+      debug "Copying annotation file ${extra_annotation_file} to ${output_directory}/${sanitized_title}_annotations.json"
+      cp "${extra_annotation_file}" "${output_directory}/${sanitized_title}_annotations.json"
+      debug "Generating CSV annotations file ${output_directory}/${sanitized_title}_annotations.csv"
+      jq -r '["Type","Start Time","End Time","Note"], (.payload.records[] | select(.type == "audible.last_heard" or .type == "audible.bookmark" or .type == "audible.clip") | [.type, (.startPosition | tonumber / 1000 | strftime("%H:%M:%S")), (if .type == "audible.clip" and .endPosition then (.endPosition | tonumber / 1000 | strftime("%H:%M:%S")) else "N/A" end), (if .type == "audible.clip" and .metadata.title then .metadata.title else (.note // "N/A") end)]) | @csv' "${extra_annotation_file}" > "${output_directory}/${sanitized_title}_annotations.csv"
+    fi
+  fi
 
   # Move the aax file if the decode is completed and the --complete_dir is set to a valid location.
   # Check the target dir for if set if it is writable

--- a/AAXtoMP3-cheat-sheet.md
+++ b/AAXtoMP3-cheat-sheet.md
@@ -1,0 +1,36 @@
+# AAXtoMP3 Cheat Sheet
+
+**Purpose:** Convert `.aax`/`.aaxc` to `.m4a`/`.mp3`/`.flac`/`.opus` with metadata/chapters. `.aax` requires auth code; `.aaxc` uses `.voucher`.
+
+**Commands:**
+- **Help:** Show all options.
+  ```bash
+  AAXtoMP3 -h
+  ```
+- **Convert Single Book (AAC, .aax):** Converts to `.m4a` with metadata/chapters.
+  ```bash
+  AAXtoMP3 -a -A <your_code> --use-audible-cli-data -t <path_to_output_folder> <path_to_input_file.aax>
+  ```
+  - Example: Audiobook-LC_128_44100_stereo.aax located in ~/Downloads/Audible/Audiobook/
+    ```bash
+    AAXtoMP3 -a -A <your_code> --use-audible-cli-data -t ~/Downloads ~/Downloads/Audible/Audiobook/Audiobook-LC_128_44100_stereo.aax
+    ```
+- **Convert Single Book (AAC, .aaxc):** No auth code needed.
+  ```bash
+  AAXtoMP3 -a --use-audible-cli-data -t <path_to_output_folder> <path_to_input_file.aaxc>
+  ```
+- **Convert Single Book (MP3):** Converts to `.mp3`. **NOTE: 10-15% larger than AAC; prefer AAC for efficiency.**
+  ```bash
+  AAXtoMP3 -s -A <your_code> --use-audible-cli-data -t <path_to_output_folder> <path_to_input_file>
+  ```
+- **Batch Convert (AAC, .aax, .aaxc):** Converts all `.aax`/`.aaxc` to `.m4a`.
+  ```bash
+  for f in <path_to_input_folder>/*.aax*; do AAXtoMP3 -a --use-audible-cli-data -t <path_to_output_folder> "$f"; done > ~/<path_to_log_folder>/conversion_log.txt 2>&1
+  ```
+  - Example: all audiobooks downloaded to ~/Downloads/Audible, converted to ~/Downloads/AAC, and logged to ~/Downloads
+  ```bash
+  for f in ~/Downloads/Audible/*.aax*; do AAXtoMP3 -a --use-audible-cli-data -t ~/Downloads/AAC "$f"; done > ~/Downloads/conversion_log.txt 2>&1
+  ```
+- **Debug Mode:** Verbose logs.
+  ```bash
+  AAXtoMP3 -a -A <your_code> --use-audible-cli-data -d -t <path_to_output_folder> <path_to_input_file>

--- a/README.md
+++ b/README.md
@@ -12,20 +12,38 @@ your **personal** Audible account. The purpose of this software is to
 create a method for you to download and store your books just in case
 Audible fails for some reason.
 
+Forked by kcrvM4 from [krad/AAXtoMP3](https://github.com/krad/AAXtoMP3) with minor bug fixes and enhancements.
+
+## Features
+* Converts `.aax`/`.aaxc` to single (-s) or chaptered (-c) `.m4a`/`.m4b` with `-a` or `-e:m4a/-e:m4b`.
+* Embeds cover art using `mp4art` and chapters using `mp4chaps` for `.m4a/.m4b`.
+* Supports `--use-audible-cli-data` for JSON-based chapters and annotations.
+* Sanitizes directory and file names (replaces /, \, *, <, >, |, ?, " with _, : with ' -', ; with ,, removes .).
+* Cleans up `cover.jpg` and `.chapters.txt` post-conversion if embedded (can be disabled with **--no-cleanup** option).
+* Copies `-annotations.json` and generates a `.csv` file (with `Type`, `Start Time`, `End Time`, `Note` headers) to output directory.
+
 ## Requirements
-* bash 3.2.57 or later tested
-* ffmpeg version 2.8.3 or later (4.4 or later if the input file is `.aaxc`)
-* libmp3lame - (typically 'lame' in your system's package manager)
-* GNU grep - macOS or BSD users may need to install through package manager
-* GNU sed - see above
-* GNU find - see above
-* jq - only if `--use-audible-cli-data` is set or if converting an .aaxc file
-* mp4art used to add cover art to m4a and m4b files. Optional
-* mediainfo used to add additional media tags like narrator. Optional
+* `bash` 3.2.57 or later tested
+* `ffmpeg` version 2.8.3 or later (4.4 or later if the input file is `.aaxc`)
+* `libmp3lame` (typically 'lame' in your system's package manager)
+* `grep`, `sed`, `find` (GNU versions; macOS/BSD users may need to install via package manager)
+* `jq` - only required if `--use-audible-cli-data` is set or if converting an `.aaxc` file
+* `bc` (for bitrate calculations)
+* `mp4v2` (provides both mp4art and mp4chaps) (OPTIONAL)
+  * `mp4art` used to add cover art to `.m4a` and `.m4b` files. (OPTIONAL)
+  * `mp4chaps` used to add chapters to `.m4a` and `.m4b` files. (OPTIONAL)
+* `mediainfo` used to add additional media tags like narrator. (OPTIONAL)
+
+## Conversion Suggestions
+### Choosing Your Output Format
+Choose your output format carefully to save time and space (and avoid redoing your library later)! While `.mp3` is the default, `.m4a` or `.m4b` (via `-a`, `-e:m4a`, or `-e:m4b`) support embedded cover art and chapters, enhancing the listening experience. AAC is also 20-30x faster than MP3 due to no transcoding and has similar file size at the same quality level.
+
+### Preserving Annotations
+Don’t lose your notes and bookmarks! The `-annotations.json` file stores these and can be downloaded using `audible-cli` with the `--annotation` flag. When `--use-audible-cli-data` is enabled, the script copies `<title>-annotations.json` to `<sanitized_title>_annotations.json` and generates `<sanitized_title>_annotations.csv` with headers `Type`, `Start Time`, `End Time`, `Note`. While not embedded in the audiobook, you can easily view your annotations or import them into compatible players.
 
 ## Usage(s)
 ```
-bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|--aac] [-s|--single] [--level <COMPRESSIONLEVEL>] [-c|--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [-A|--authcode <AUTHCODE>] [-n|--no-clobber] [-t|--target_dir <PATH>] [-C|--complete_dir <PATH>] [-V|--validate] [--use-audible-cli-data]] [-d|--debug] [-h|--help] [--continue <CHAPTERNUMBER>] <AAX/AAXC INPUT_FILES>...
+bash AAXtoMP3 [-f|--flac] [-o|--opus] [-a|--aac] [-s|--single] [--level <COMPRESSIONLEVEL>] [-c|--chaptered] [-e:mp3] [-e:m4a] [-e:m4b] [-A|--authcode <AUTHCODE>] [-N|--no-cleanup] [-n|--no-clobber] [-t|--target_dir <PATH>] [-C|--complete_dir <PATH>] [-V|--validate] [--use-audible-cli-data]] [-d|--debug] [-h|--help] [--continue <CHAPTERNUMBER>] <AAX/AAXC INPUT_FILES>...
 ```
 or if you want to get guided through the options
 ```
@@ -51,8 +69,8 @@ bash interactiveAAXtoMP3 [-a|--advanced] [-h|--help]
 * **--continue &lt;CHAPTERNUMBER&gt;**      If the splitting into chapters gets interrupted (e.g. by a weak battery on your laptop) you can go on where the process got interrupted. Just delete the last chapter (which was incompletely generated) and redo the task with "--continue &lt;CHAPTERNUMBER&gt;" where CHAPTERNUMBER is the chapter that got interrupted.
 * **--level &lt;COMPRESSIONLEVEL&gt;**      Set compression level. May be given for mp3, flac and opus.
 * **--keep-author &lt;FIELD&gt;**           If a book has multiple authors and you don't want all of them in the metadata, with this flag you can specify a specific author (1 is the first, 2 is the second...) to keep while discarding the others.
-* **--author &lt;AUTHOR&gt;**               Manually set the author metadata field, useful if you have multiple books of the same author but the name reported is different (eg. spacing, accents..). Has precedence over `--keep-author`.
-* **-l** or **--loglevel &lt;LOGLEVEL&gt;** Set loglevel: 0 = progress only, 1 (default) = more information, output of chapter splitting progress is limitted to a progressbar, 2 = more information, especially on chapter splitting, 3 = debug mode
+* **--author &lt;AUTHOR&gt;**               Manually set the author metadata field, useful if you have multiple books of the same author but the name reported is different (e.g., spacing, accents..). Has precedence over `--keep-author`.
+* **-l** or **--loglevel &lt;LOGLEVEL&gt;** Set loglevel: 0 = progress only, 1 (default) = more information, output of chapter splitting progress is limited to a progress bar, 2 = more information, especially on chapter splitting, 3 = debug mode
 * **--dir-naming-scheme &lt;STRING&gt;** or **-D**      Use a custom directory naming scheme, with variables. See [below](#custom-naming-scheme) for more info.
 * **--file-naming-scheme &lt;STRING&gt;** or **-F**    Use a custom file naming scheme, with variables. See [below](#custom-naming-scheme) for more info.
 * **--chapter-naming-scheme &lt;STRING&gt;**  Use a custom chapter naming scheme, with variables. See [below](#custom-naming-scheme) for more info.
@@ -61,6 +79,7 @@ bash interactiveAAXtoMP3 [-a|--advanced] [-h|--help]
 * **--ffmpeg-path**  Set the ffmpeg/ffprobe binaries folder. Both of them must be executable and in the same folder.
 * **--ffmpeg-name**  Set a custom name for the ffmpeg binary. Must be executable and in path, or in custom path specified by --ffmpeg-path.
 * **--ffprobe-name**  Set a custom name for the ffprobe binary. Must be executable and in path, or in custom path specified by --ffmpeg-path.
+* **--no-cleanup**  Leaves cover.jpg and/or chapter.txt files in output directory after successful embedding.
 
 ## Options for interactiveAAXtoMP3
 * **-a** or **--advanced** Get more options to choose. Not used right now.
@@ -76,9 +95,10 @@ You will need your authentication code that comes from Audible's servers. This
 will be used by ffmpeg to perform the initial audio convert. You can obtain 
 this string from a tool like 
 [audible-activator](https://github.com/inAudible-NG/audible-activator) or like [audible-cli](https://github.com/mkb79/audible-cli).
+* [audible-cli] command to obtain the authentication code for .aax files: `audible activation-bytes`
 
 #### Specifying the AUTHCODE.
-In order of __precidence__.
+In order of __precedence__.
 1. __--authcode [AUTHCODE]__ The command line option. With the highest precedence.
 2. __.authcode__ If this file is placed in the current working directory and contains only the authcode it is used if the above is not.
 3. __~/.authcode__ a global config file for all the tools. And is used as the default if none of the above are specified.
@@ -88,15 +108,15 @@ __Note:__ At least one of the above must be exist if converting `aax` files. The
 * This is the **default** encoding
 * Produces 1 or more mp3 files for the AAX title.
 * The default mode is **chaptered**
-* If you want a mp3 file per chapter do not use the **--single** option. 
-* A m3u playlist file will also be created in this instance in the case of **default** chaptered output.
-* **--level** has to be in range 0-9, where 9 is fastest and 0 is highest quality. Please note: The quality can **never** become higher than the qualitiy of the original aax file!
+* If you want an mp3 file for each chapter, do not use the **--single** option. 
+* A m3u playlist file will also be created when using the **--chaptered** option.
+* **--level** has to be in range 0-9, where 9 is fastest and 0 is highest quality. Please note: The quality can **never** become higher than the quality of the original aax file!
 
 ### Ogg/Opus Encoding
 * Can be done by using the **-o** or **--opus** command line switches
 * The default mode is **chaptered**
 * Opus coded files are stored in the ogg container format for better compatibility.
-* **--level** has to be in range 0-10, where 0 is fastest and 10 is highest quality. Please note: The quality can **never** become higher than the qualitiy of the original aax file!
+* **--level** has to be in range 0-10, where 0 is fastest and 10 is highest quality. Please note: The quality can **never** become higher than the quality of the original aax file!
 
 ### AAC Encoding
 * Can be done by using the **-a** or **--aac** command line switches
@@ -116,23 +136,23 @@ __Note:__ At least one of the above must be exist if converting `aax` files. The
 * These containers were created by Apple Inc. They were meant to be the successor to mp3.
 * M4A is a container that is meant to hold music and is typically of a higher bitrate.
 * M4B is a container that is meant to hold audiobooks and is typically has bitrates of 64k and 32k.
-* Both formats are chaptered
-* Both support coverart internal
+* Both formats support embedded chapters
+* Both formats support embedded cover art
 * The default mode is **single**
 
 ### Validating AAX files
 * The **--validate** option will result in only a validation pass over the supplied aax file(s). No transcoding will occur. This is useful when you wish to ensure you have a proper download of your personal Audible audio books. With this option all supplied books are validated.
 * If you do NOT supply the **--validate** option all audio books are still validated when they are processed. However if there is an invalid audio book in the supplied list of books the processing will stop at that point.
 * A third test is performed on the file where the entire file is inspected to see if it is valid. This is a lengthy process. However it will not break the script when an invalid file is found.
-* The 3 test current are:
+* The 3 tests currently are:
     1. aax present
-    1. meta data header in file is valid and complete
-    1. entire file is valid and complete.  _only executed with the **--validate** option._
+    2. meta data header in file is valid and complete
+    3. entire file is valid and complete.  _only executed with the **--validate** option._
 
 ### Defaults
 * Default out put directory is the base directory of each file listed. Plus the genre, Artist and Title of the Audio Book.
 * The default codec is mp3
-* The default output is by chapter.
+* The default output is one file per chapter.
 
 ### Custom naming scheme
 The following flags can modify the default naming scheme:
@@ -165,13 +185,13 @@ In general, take a look at [command-not-found.com](https://command-not-found.com
 __Ubuntu, Linux Mint, Debian__
 ```
 sudo apt-get update
-sudo apt-get install ffmpeg libav-tools x264 x265 bc
+sudo apt-get install ffmpeg x264 x265 bc jq
 ```
 
 In Debian-based system's repositories the ffmpeg version is often outdated. If you want
-to convert .aaxc files, you need at least ffmpeg 4.4. So if your installed version
-needs to be updated, you can either install a custom repository that has the newer version,
-compile ffmpeg from source or download pre-compiled binaries.
+to convert .aaxc files, you need at least ffmpeg 4.4 (check with `ffmpeg -version`).
+So if your installed version needs to be updated, you can either install a custom repository
+that has the newer version, compile ffmpeg from source or download pre-compiled binaries.
 You can then tell AAXtoMP3 to use the compiled binaries with the `--ffmpeg-path` flag.
 You need to specify the folder where the ffmpeg and ffprobe binaries are. Make sure
 they are both executable.
@@ -180,7 +200,7 @@ If you have snapd installed, you can also install a recent version of 4.4 from t
 ```
 snap install ffmpeg --edge
 ```
-In this case you will need to confiure a custom path _and_ binary name for ffprobe, `--ffmpeg-path /snap/bin/ --ffprobe-name ffmpeg.ffprobe`.
+In this case you will need to configure a custom path _and_ binary name for ffprobe, `--ffmpeg-path /snap/bin/ --ffprobe-name ffmpeg.ffprobe`.
 
 __Fedora__
 
@@ -219,17 +239,20 @@ brew install grep
 brew install findutils
 ```
 
-#### mp4art/mp4chaps
+#### mp4art/mp4chaps (part of mp4v2-utils package)
 _Note: This is an optional dependency, required for adding cover art to m4a and b4b files only._
 
 __Ubuntu, Linux Mint, Debian__
-```
-sudo apt-get update
-sudo apt-get install mp4v2-utils
+
+Build from https://github.com/enzo1982/mp4v2
+
+```bash
+git clone https://github.com/enzo1982/mp4v2
+cd mp4v2
+./configure && make && sudo make install
 ```
 
-On Debian and Ubuntu the mp4v2-utils package has been deprecated and removed, as the upsteam project is no longer maintained.
-The package was removed in Debian Buster, and Ubuntu Focal [ 20.04 ].
+On Debian and Ubuntu the mp4v2-utils package has been deprecated and removed from the repo, as the upstream project is no longer maintained.The package was removed in Debian Buster, and Ubuntu Focal [ 20.04 ].
 
 __CentOS, RHEL & Fedora__
 ```
@@ -262,30 +285,32 @@ The AAXC format is a new Audible encryption format, meant to replace the old AAX
 The encryption has been updated, and now to decrypt the file the authcode
 is not sufficient, we need two "keys" which are unique for each audiobook.
 Since getting those keys is not simple, for now the method used to get them
-is handled by the package audible-cli, that stores
-them in a file when downloading the aaxc file. This means that in order to
-decrypt the aaxc files, they must be downloaded with audible-cli.
+is handled by the package audible-cli, that stores them in a .voucher file
+when downloading the aaxc file. This means that in order to decrypt the
+aaxc files, they must be downloaded with audible-cli.
+
 Note that you need at least [ffmpeg 4.4](#ffmpegffprobe).
 
 ## Audible-cli integration
-Some information are not present in the AAX file. For example the chapters's
+Some information is not present in the AAX file--for example, the chapter's
 title, additional chapters division (Opening and End credits, Copyright and
-more).  Those information are avaiable via a non-public audible API. This
+more). This information are available via a non-public audible API. This
 [repo](https://github.com/mkb79/Audible) provides a python API wrapper, and the
-[audible-cli](https://github.com/mkb79/audible-cli) packege makes easy to get
+[audible-cli](https://github.com/mkb79/audible-cli) package makes easy to get
 more info. In particular the flags **--cover --cover-size 1215 --chapter**
-downloads a better-quality cover (.jpg) and detailed chapter infos (.json).
-More info are avaiable on the package page.
+downloads a better-quality cover (.jpg) and detailed chapter info (.json). The
+flag **--annotation** downloads a .json file containing your notes and bookmarks.
+More info is available on the package page.
 
-Some books might not be avaiable in the old `aax` format, but only in the newer
+Some books might not be available in the old `aax` format, but only in the newer
 `aaxc` format. In that case, you can use [audible-cli](https://github.com/mkb79/audible-cli)
 to download them. For example, to download all the books in your library in the newer `aaxc` format, as well as
-chapters's title and an HQ cover: `audible download --all --aaxc --cover --cover-size 1215 --chapter`.
+chapter's title and an HQ cover: `audible download --all --aaxc --cover --cover-size 1215 --chapter`.
 
 To make AAXtoMP3 use the additional data, specify the **--use-audible-cli-data**
-flag: it expects the cover and the chapter files (and the voucher, if converting
-an aaxc file) to be in the same location of the AAX file.  The naming of these
-files must be the one set by audible-cli. When converting aaxc files, the variable
+flag: it expects the cover, chapter, and annotations files (and the voucher, if converting
+an aaxc file) to be in the same location of the AAX / AAXC file.  The naming of these
+files must be the one set by audible-cli. When converting AAXC files, this flag
 is automatically set, so be sure to follow the instructions in this paragraph.
 
 For more information on how to use the `audible-cli` package, check out the git page [audible-cli](https://github.com/mkb79/audible-cli).
@@ -293,7 +318,14 @@ For more information on how to use the `audible-cli` package, check out the git 
 Please note that right now audible-cli is in dev stage, so keep in mind that the
 naming scheme of the additional files, the flags syntax and other things can
 change without warning.
+
+## Cover Art
+The script expects a single `.jpg` cover art file in the format `BookTitle_(###).jpg`; however, the highest resolution will be selected if multiple files exist (e.g., `BookTitle_(500).jpg`, `BookTitle_(1215).jpg` picks 1215).
  
+## Cheat Sheets
+For quick reference, check out these tested command guides:
+* [AAXtoMP3 Cheat Sheet](AAXtoMP3_cheatsheet.md): Common conversion commands and flags, including batch conversion.
+* [Audible-cli Cheat Sheet](audible-cli_cheatsheet.md): Handy commands for downloading `.aaxc`, covers, chapters, and annotations.
 
 ## Anti-Piracy Notice
 Note that this project **does NOT ‘crack’** the DRM. It simply allows the user to
@@ -313,4 +345,5 @@ This blurb is borrowed from the https://apprenticealf.wordpress.com/ page.
 Changed the license to the WTFPL, do whatever you like with this script. Ultimately it's just a front-end for ffmpeg after all.
 
 ## Need Help?
-I'll help out if you are having issues, just submit and issue and I'll get back to you when I can.
+I'll help out if you are having issues, just submit an issue and I'll get back to you when I can.
+

--- a/audible-cli-cheat-sheet.md
+++ b/audible-cli-cheat-sheet.md
@@ -1,0 +1,46 @@
+# audible-cli Cheat Sheet
+
+**Purpose:** Download Audible audiobooks as `.aax` (legacy, DRM-protected, needs auth code) or `.aaxc` (newer, uses `.voucher` for DRM, no auth code). Use `--chapter`, `--cover` and `--annotation` to get `<title>-chapters.json`, `<title>_(500).jpg` and `<title>-annotations.json` for metadata; `.voucher` only contains DRM keys.
+
+**Commands:**
+- **Help:** Show all options.
+  ```bash
+  audible -h
+  audible download -h
+  ```
+- **Login/Setup:** Authenticate with Audible account.
+  ```bash
+  audible quickstart
+  ```
+- **Get Auth Code:** Retrieve 8-digit authentication code (needed for AAXtoMP3 .aax file conversion).
+  ```bash
+  audible activation-bytes
+  ```
+- **Export Library:** Export complete details of books in library. Default output folder is <Home>/ if -o flag is not used. Default format is .tsv, but .csv and .json are also available.
+  ```bash
+  audible library export --start-date <YYYY-MM-DD> -o <path_to_output_folder>
+  ```
+- **Check Library:** List ASINs of owned books. Handy for quick lookup for a single download. **NOTE: ASIN can also be found in book's webpage URL.**
+  ```bash
+  audible library list --start-date <YYYY-MM-DD>
+  ```
+- **Download Single Book (.aax):** Downloads `.aax`, JSON, cover. Will fallback to .aaxc if .aax is not available. **NOTE: Output (target) directory must exist if specifying--program will not create new folders.**
+  ```bash
+  audible download -a <ASIN> --aax-fallback --cover --chapter --annotation -o <path_to_output_folder>
+  ```
+- **Download Single Book (.aaxc):** Downloads `.aaxc`, `.voucher`, JSON, high-resolution cover. **NOTE: Output (target) directory must exist if specifying--program will not create new folders.**
+  ```bash
+  audible download -a <ASIN> --aaxc --cover --cover-size 1215 --chapter --annotation -o <path_to_output_folder>
+  ```
+- **Download Books Added After a Date:** Downloads .aaxc books added to library on or after the specified UTC date. **NOTE: Output (target) directory must exist if specifying--program will not create new folders.**
+  ```bash
+  audible download --all --aaxc --cover --chapter --annotation --start-date <YYYY-MM-DD> -o <path_to_output_folder>
+  ```
+  - Example: Books added after May 1, 2025
+    ```bash
+    audible download --all --aaxc --cover --chapter --ignore-errors --annotation --start-date 2025-05-01 -o ~/Downloads/Audible
+    ```
+- **Download All Books:** Downloads entire library as `.aaxc`. **NOTE: Output (target) directory must exist if specifying--program will not create new folders.**
+  ```bash
+  audible download --all --aaxc --chapter --cover --ignore-errors --annotation -o <path_to_output_folder>
+  ```


### PR DESCRIPTION
- Annotations support: Copy -annotations.json and generate CSV (Type, Start Time, End Time, Note).
- Sanitized title/artist naming: Replace invalid characters for directories/files/chapters.
- Nested chapter parsing for correct --chaptered output.
- Highest-resolution cover art selection.
- Added jq dependency check and chapter ffprobe fallback.
- Added cover/chapter embed tracking and temporary file cleanup.
- Added --no-cleanup flag.
- Updated mp4art/mp4chaps checks for deprecated mp4v2-utils.
- Updated README.
- Added cheat sheets. Tested on Linux Mint 22.2 with 100+ Audible .aaxc files.